### PR TITLE
⏺ refactor: change DataRate variant to use named field

### DIFF
--- a/src/units/parser.rs
+++ b/src/units/parser.rs
@@ -156,9 +156,9 @@ pub fn parse_unit(text: &str) -> Option<Unit> {
             Box::new(Unit::Request),
             Box::new(Unit::Second),
         )),
-        "req/min" | "req/minute" | "requests/min" | "requests/minute" | "rpm" => Some(
-            rate_unit!(Unit::Request, Unit::Minute),
-        ),
+        "req/min" | "req/minute" | "requests/min" | "requests/minute" | "rpm" => {
+            Some(rate_unit!(Unit::Request, Unit::Minute))
+        }
         "req/h" | "req/hour" | "requests/h" | "requests/hour" | "rph" => Some(Unit::RateUnit(
             Box::new(Unit::Request),
             Box::new(Unit::Hour),
@@ -171,9 +171,7 @@ pub fn parse_unit(text: &str) -> Option<Unit> {
             Box::new(Unit::Query),
             Box::new(Unit::Minute),
         )),
-        "qph" | "queries/h" | "queries/hour" => {
-            Some(rate_unit!(Unit::Query, Unit::Hour))
-        }
+        "qph" | "queries/h" | "queries/hour" => Some(rate_unit!(Unit::Query, Unit::Hour)),
 
         "%" | "percent" | "percentage" => Some(Unit::Percent),
 
@@ -185,8 +183,7 @@ pub fn parse_unit(text: &str) -> Option<Unit> {
                     let right_unit = parse_unit(&text[slash_pos + 1..]);
                     if let (Some(left_unit), Some(right_unit)) = (left_unit, right_unit) {
                         if right_unit.unit_type() == UnitType::Time {
-                            rate_type =
-                                Some(rate_unit!(left_unit, right_unit))
+                            rate_type = Some(rate_unit!(left_unit, right_unit))
                         }
                     }
                 }

--- a/src/units/tests.rs
+++ b/src/units/tests.rs
@@ -150,13 +150,28 @@ fn test_generic_rate_edge_cases() {
 
     // Test rate unit type classification
     let rate = rate_unit!(Unit::GiB, Unit::Minute);
-    assert_eq!(rate.unit_type(), UnitType::DataRate(60.0)); // 60 seconds per minute
+    assert_eq!(
+        rate.unit_type(),
+        UnitType::DataRate {
+            time_multiplier: 60.0
+        }
+    ); // 60 seconds per minute
 
     let rate = rate_unit!(Unit::MB, Unit::Hour);
-    assert_eq!(rate.unit_type(), UnitType::DataRate(3600.0)); // 3600 seconds per hour
+    assert_eq!(
+        rate.unit_type(),
+        UnitType::DataRate {
+            time_multiplier: 3600.0
+        }
+    ); // 3600 seconds per hour
 
     let rate = rate_unit!(Unit::KB, Unit::Day);
-    assert_eq!(rate.unit_type(), UnitType::DataRate(86400.0)); // 86400 seconds per day
+    assert_eq!(
+        rate.unit_type(),
+        UnitType::DataRate {
+            time_multiplier: 86400.0
+        }
+    ); // 86400 seconds per day
 }
 
 #[test]
@@ -229,26 +244,26 @@ fn test_rate_unit_addition() {
         evaluate_test_expression("1 GiB/hour + 1 GiB/minute"),
         Some("61 GiB/h".to_string()) // 1 + (1 * 60) = 61 GiB/hour
     );
-    
+
     // Test addition of same rate units
     assert_eq!(
         evaluate_test_expression("100 MB/s + 50 MB/s"),
         Some("150 MB/s".to_string())
     );
-    
+
     // Test bit rate addition
     assert_eq!(
         evaluate_test_expression("1 Gb/s + 500 Mb/s"),
         Some("1,500 Mb/s".to_string()) // Result in smaller unit (Mb)
     );
-    
+
     // Test request rate addition
     assert_eq!(
         evaluate_test_expression("100 req/s + 200 req/s"),
         Some("300 req/s".to_string())
     );
 
-    // Test subtraction of rate units  
+    // Test subtraction of rate units
     assert_eq!(
         evaluate_test_expression("2 GiB/hour - 1 GiB/minute"),
         Some("-58 GiB/h".to_string()) // 2 - (1 * 60) = -58 GiB/hour
@@ -1227,19 +1242,27 @@ fn test_large_data_unit_type_classification() {
     // Test that large rate units are properly classified
     assert_eq!(
         rate_unit!(Unit::PB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::EB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::PiB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::EiB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
 }
 
@@ -1629,31 +1652,45 @@ fn test_bit_byte_unit_type_classification() {
     // Test that byte rate units are still classified as DataRate type
     assert_eq!(
         rate_unit!(Unit::Byte, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::KB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::MB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::GB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::KiB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::MiB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
     assert_eq!(
         rate_unit!(Unit::GiB, Unit::Second).unit_type(),
-        UnitType::DataRate(1.0)
+        UnitType::DataRate {
+            time_multiplier: 1.0
+        }
     );
 }
 

--- a/src/units/types.rs
+++ b/src/units/types.rs
@@ -85,7 +85,7 @@ pub enum UnitType {
     Data,
     Request,
     BitRate,
-    DataRate(f64),
+    DataRate { time_multiplier: f64 },
     RequestRate,
     Percentage,
 }
@@ -264,7 +264,9 @@ impl Unit {
                 }
                 match b1.unit_type() {
                     UnitType::Bit => UnitType::BitRate,
-                    UnitType::Data => UnitType::DataRate(b2.to_base_value(1.0)),
+                    UnitType::Data => UnitType::DataRate {
+                        time_multiplier: b2.to_base_value(1.0),
+                    },
                     UnitType::Request => UnitType::RequestRate,
                     _ => panic!("Rate unknown"),
                 }
@@ -387,29 +389,31 @@ impl Unit {
     pub fn is_compatible_for_addition(&self, other: &Unit) -> bool {
         let self_type = self.unit_type();
         let other_type = other.unit_type();
-        
+
         // Direct unit type match (this covers most cases including exact rate matches)
         if self_type == other_type {
             return true;
         }
-        
+
         // Special case for rate units with different time units but same data units
         match (self, other) {
             (Unit::RateUnit(self_data, self_time), Unit::RateUnit(other_data, other_time)) => {
                 // Both must be time denominators
-                if self_time.unit_type() != UnitType::Time || other_time.unit_type() != UnitType::Time {
+                if self_time.unit_type() != UnitType::Time
+                    || other_time.unit_type() != UnitType::Time
+                {
                     return false;
                 }
-                
+
                 // For data rates, we need EXACT data unit type compatibility
                 // This means GiB (base-2) and MB (base-10) are NOT compatible
                 let self_data_type = self_data.unit_type();
                 let other_data_type = other_data.unit_type();
-                
+
                 match (self_data_type, other_data_type) {
                     // Bit rates are only compatible with other bit rates
                     (UnitType::Bit, UnitType::Bit) => true,
-                    // Request rates are only compatible with other request rates  
+                    // Request rates are only compatible with other request rates
                     (UnitType::Request, UnitType::Request) => true,
                     // Data rates are compatible only if from same base system
                     (UnitType::Data, UnitType::Data) => {
@@ -425,6 +429,9 @@ impl Unit {
 
     /// Check if this is a base-2 data unit (KiB, MiB, GiB, etc.)
     fn is_base2_data(&self) -> bool {
-        matches!(self, Unit::KiB | Unit::MiB | Unit::GiB | Unit::TiB | Unit::PiB | Unit::EiB)
+        matches!(
+            self,
+            Unit::KiB | Unit::MiB | Unit::GiB | Unit::TiB | Unit::PiB | Unit::EiB
+        )
     }
 }

--- a/src/units/value.rs
+++ b/src/units/value.rs
@@ -53,7 +53,7 @@ impl UnitValue {
         use super::types::UnitType;
         matches!(
             (current.unit_type(), target.unit_type()),
-            (UnitType::DataRate(_), UnitType::DataRate(_))
+            (UnitType::DataRate { .. }, UnitType::DataRate { .. })
         )
     }
 
@@ -64,8 +64,8 @@ impl UnitValue {
             (current.unit_type(), target.unit_type()),
             (UnitType::Bit, UnitType::Data)
                 | (UnitType::Data, UnitType::Bit)
-                | (UnitType::BitRate, UnitType::DataRate(_))
-                | (UnitType::DataRate(_), UnitType::BitRate)
+                | (UnitType::BitRate, UnitType::DataRate { .. })
+                | (UnitType::DataRate { .. }, UnitType::BitRate)
         )
     }
 
@@ -89,14 +89,14 @@ impl UnitValue {
                 Some(UnitValue::new(converted_value, Some(target.clone())))
             }
             // Bit rate to Byte rate conversion
-            (UnitType::BitRate, UnitType::DataRate(_seconds)) => {
+            (UnitType::BitRate, UnitType::DataRate { .. }) => {
                 let bits_per_sec = current.to_base_value(self.value); // Convert to base bits/sec
                 let bytes_per_sec = bits_per_sec / 8.0; // 8 bits/sec = 1 byte/sec
                 let converted_value = target.clone().from_base_value(bytes_per_sec);
                 Some(UnitValue::new(converted_value, Some(target.clone())))
             }
             // Byte rate to Bit rate conversion
-            (UnitType::DataRate(_seconds), UnitType::BitRate) => {
+            (UnitType::DataRate { .. }, UnitType::BitRate) => {
                 let bytes_per_sec = current.to_base_value(self.value); // Convert to base bytes/sec
                 let bits_per_sec = bytes_per_sec * 8.0; // 1 byte/sec = 8 bits/sec
                 let converted_value = target.clone().from_base_value(bits_per_sec);


### PR DESCRIPTION
  Change UnitType::DataRate from anonymous tuple DataRate(f64) to
  named struct DataRate { time_multiplier: f64 } for better code clarity.

  - Update enum definition in units/types.rs
  - Fix all pattern matching across value.rs, tests.rs, and evaluator.rs
  - Update construction sites to use named field syntax
  - All tests pass and functionality preserved

  🤖 Generated with [Claude Code](https://claude.ai/code) with the prompt:
  in UnitType, I would like the DataRate variant to use a named field (time_multiplier), instead of an anonymous tuple